### PR TITLE
patch: Use temp directory and clean up executable

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -28,6 +28,7 @@ jobs:
           echo "MajorMinorPatch: ${{ steps.jjversion.outputs.majorMinorPatch }}"
           echo "Sha: ${{ steps.jjversion.outputs.sha }}"
           echo "ShortSha: ${{ steps.jjversion.outputs.shortSha }}"
+      - run: Get-ChildItem -Name
 
   actions-skip-go-install:
     strategy:
@@ -59,3 +60,5 @@ jobs:
           echo "MajorMinorPatch: ${{ steps.jjversion.outputs.majorMinorPatch }}"
           echo "Sha: ${{ steps.jjversion.outputs.sha }}"
           echo "ShortSha: ${{ steps.jjversion.outputs.shortSha }}"
+      - run: Get-ChildItem -Name
+

--- a/action.yaml
+++ b/action.yaml
@@ -41,10 +41,15 @@ runs:
     - name: Setup Go unless skip-go-installation is true
       uses: actions/setup-go@02f7ea9f09887fd7fd6c77c49a0f72a2e8cde95c
       if: ${{ inputs.skip-go-installation != 'true' }}
+    - run: mkdir jjversion
+      shell: pwsh
+      working-directory: ${{ runner.temp }}
     - run: go mod init local
       shell: pwsh
+      working-directory: ${{ runner.temp }}/jjversion
     - run: go get -v -d github.com/jjliggett/jjversion-gha-output@9c0f517e6b33bae4c09f69b453a7929fada44f94
       shell: pwsh
+      working-directory: ${{ runner.temp }}/jjversion
     - run: ls "$(go env GOPATH)/pkg/mod/github.com/jjliggett"
       shell: pwsh
     - run: |
@@ -89,4 +94,12 @@ runs:
         echo "MajorMinorPatch: ${{ steps.jjversion.outputs.majorMinorPatch }}"
         echo "Sha: ${{ steps.jjversion.outputs.sha }}"
         echo "ShortSha: ${{ steps.jjversion.outputs.shortSha }}"
+      shell: pwsh
+    - run: |
+        if ($env:RUNNER_OS -eq "Windows")
+        {
+          rm ./jjversion-gha-output.exe
+        } else {
+          rm ./jjversion-gha-output
+        }
       shell: pwsh


### PR DESCRIPTION
This makes it so that the go.mod and go.sum files are not added in the workspace directory and it makes it so that the versioning executable does not remain in the workspace after the action completes.