### PR TITLE
feat: Download jjversion-ghao executable binaries with curl from GitHub release for better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,6 @@ jjversion-action is a composite GitHub action that uses the Go package [jjligget
 
 For this action to work properly, you must create a versioning.yaml file in your repository and checkout your repository in your workflow with ```fetch-depth: 0``` to fetch all history for all tags and branches. Configuration information for the versioning.yaml file can be found in the <https://github.com/jjliggett/jjversion> repository.
 
-### Inputs
-
-The action accepts the following input:
-
-```yaml
-  skip-go-installation:
-    description: "If set to true, then the action uses pre-installed Go"
-    default: "false"
-    required: false
-```
-
 ### Outputs
 
 The action creates the following outputs:
@@ -57,7 +46,7 @@ Licensing can be found at: [LICENSE.md](LICENSE.md).
 
 The jjversion-action license applies to all parts of jjversion-action that are not externally maintained libraries and dependencies.
 
-The primary dependency of jjversion-action 0s jjversion-gha-output, located at <https://github.com/jjliggett/jjversion-gha-output>. Its license can be found in that repository. This action installs jjversion-gha-output from the GitHub jjliggett/jjversion-gha-output repository.
+The primary dependency of jjversion-action is jjversion-gha-output, located at <https://github.com/jjliggett/jjversion-gha-output>. Its license can be found in that repository. This action downloads a GitHub Release executable binary from the jjliggett/jjversion-gha-output repository and executes it.
 
 Another core dependency of jjversion-action is jjversion, which is a dependency of jjversion-gha-output. This is located at <https://github.com/jjliggett/jjversion>. Its license and the licenses for its dependencies can be found in the jjversion repository.
 

--- a/action.yaml
+++ b/action.yaml
@@ -4,11 +4,6 @@ author: "jjliggett"
 branding:
   icon: "tag"
   color: "blue"
-inputs:
-  skip-go-installation:
-    description: "If set to true, then the action uses pre-installed Go"
-    default: "false"
-    required: false
 outputs:
   major:
     description: "Major version"
@@ -32,50 +27,24 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: echo "Setting up go"
-      shell: pwsh
-      if: ${{ inputs.skip-go-installation != 'true' }}
-    - run: echo "Skipping go setup"
-      shell: pwsh
-      if: ${{ inputs.skip-go-installation == 'true' }}
-    - name: Setup Go unless skip-go-installation is true
-      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492
-      if: ${{ inputs.skip-go-installation != 'true' }}
-    - run: mkdir jjversion
-      shell: pwsh
-      working-directory: ${{ runner.temp }}
-    - run: go mod init local
-      shell: pwsh
-      working-directory: ${{ runner.temp }}/jjversion
-    - run: go get -v -d github.com/jjliggett/jjversion-gha-output@9c0f517e6b33bae4c09f69b453a7929fada44f94
-      shell: pwsh
-      working-directory: ${{ runner.temp }}/jjversion
-    - run: ls "$(go env GOPATH)/pkg/mod/github.com/jjliggett"
+    - run: echo $env:RUNNER_OS
       shell: pwsh
     - run: |
-        cd "$(go env GOPATH)/pkg/mod/github.com/jjliggett"
         if ($env:RUNNER_OS -eq "Windows")
         {
-          cd jjversion-gha-output*
-          echo "Building jjversion-gha-output"
-          go build -o jjversion-gha-output.exe
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.2.0/jjversion-ghao.exe -L --output jjversion-gha-output.exe
+        } elseif ($env:RUNNER_OS -eq "macOS")
+        {
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.2.0/jjversion-ghao-darwin -L --output jjversion-gha-output
+          chmod +x jjversion-gha-output
         } else {
-          ls -al
-          chmod +w jjversion-gha-output*
-          ls -al
-          cd jjversion-gha-output*
-          echo "Building jjversion-gha-output"
-          go build -a -v -o jjversion-gha-output
-          cp jjversion-gha-output $env:GITHUB_WORKSPACE/jjversion-gha-output
-        }
-      shell: pwsh
-    - run: |
-        if ($env:RUNNER_OS -eq "Windows")
-        {
-          cp "$(go env GOPATH)/pkg/mod/github.com/jjliggett/jjversion-gha-output*/jjversion-gha-output.exe" .
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.2.0/jjversion-ghao -L --output jjversion-gha-output
+          chmod +x jjversion-gha-output
         }
       shell: pwsh
     - run: printenv
+      shell: pwsh
+    - run: ls
       shell: pwsh
     - run: |
         if ($env:RUNNER_OS -eq "Windows")


### PR DESCRIPTION
This change greatly enhances the performance of the GitHub action, as the binary download time is much faster than the build time, especially for Windows and Mac OS.

![image](https://user-images.githubusercontent.com/67353173/153794158-4b44efc2-5987-4f73-8440-0e9fad0dad22.png)
![image](https://user-images.githubusercontent.com/67353173/153794193-1dcd807c-d120-4787-b6ea-85228cce1f66.png)

![image](https://user-images.githubusercontent.com/67353173/153794233-26a3e188-6d76-4b0d-a2a9-3b1ca865e216.png)
![image](https://user-images.githubusercontent.com/67353173/153794270-4641b521-1450-4d6c-b0a6-8c30d532946c.png)

![image](https://user-images.githubusercontent.com/67353173/153794334-6e632bd7-ddd9-4fd4-975c-2974d45a4f55.png)
![image](https://user-images.githubusercontent.com/67353173/153794364-7c95ab82-b287-484b-929f-f11e520209d2.png)
