### PR TITLE
chore: Update dependabot commit prefixes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,5 +10,5 @@ updates:
     reviewers:
       - "jjliggett"
     commit-message:
-      prefix: "patch"
+      prefix: "ci"
       include: "scope"


### PR DESCRIPTION
This makes it so Dependabot workflow changes no longer have commit messages starting with "patch" like https://github.com/jjliggett/jjversion-action/pull/25 / https://github.com/jjliggett/jjversion-action/pull/26

also related: https://github.com/jjliggett/jjversion-action/pull/18 which simplified the jjversion-action logic