### PR TITLE
ci: Refine workflow trigger conditions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,5 +1,21 @@
 name: actions
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - README.md
+      - LICENSE.md
+      - 'docs/**'
+      - '.github/dependabot.yaml' 
+    branches:
+      - root
+  pull_request:
+    paths-ignore:
+      - README.md
+      - LICENSE.md
+      - 'docs/**'
+      - '.github/dependabot.yaml' 
+  workflow_dispatch:
+
 jobs:
   actions:
     strategy:


### PR DESCRIPTION
This change prevents duplicate pull request workflow executions.

Previously, each workflow job would run twice for pull requests, like this in #33:

![image](https://user-images.githubusercontent.com/67353173/198926375-20fef346-9344-4729-86fc-1a01cece6ed4.png)

The `workflow_dispatch` trigger was added so that testing on a branch can be performed without opening a pull request.

This is similar to https://github.com/jjliggett/jjversion-gha-output/pull/32 and https://github.com/jjliggett/jjversion/pull/140 and https://github.com/jjliggett/CurrentTimeApp/pull/50