### PR TITLE
feat: Update to jjversion-gha-output v0.3.0

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -32,13 +32,13 @@ runs:
     - run: |
         if ($env:RUNNER_OS -eq "Windows")
         {
-          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.2.4/jjversion-ghao.exe -L --output jjversion-gha-output.exe
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.0/jjversion-ghao.exe -L --output jjversion-gha-output.exe
         } elseif ($env:RUNNER_OS -eq "macOS")
         {
-          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.2.4/jjversion-ghao-darwin -L --output jjversion-gha-output
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.0/jjversion-ghao-darwin -L --output jjversion-gha-output
           chmod +x jjversion-gha-output
         } else {
-          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.2.4/jjversion-ghao -L --output jjversion-gha-output
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.0/jjversion-ghao -L --output jjversion-gha-output
           chmod +x jjversion-gha-output
         }
       shell: pwsh


### PR DESCRIPTION
This change includes several changes from github.com/jjliggett/jjversion-gha-output

The application now uses golang v1.19 - https://github.com/jjliggett/jjversion-gha-output/pull/20 and `set-output` command usage has been updated and replaced with the `GITHUB_OUTPUT` environment file - https://github.com/jjliggett/jjversion-gha-output/pull/33

Beyond that, several dependencies were updated, as seen within the following changes:

- https://github.com/jjliggett/jjversion-gha-output/pull/23
- https://github.com/jjliggett/jjversion-gha-output/pull/24
- https://github.com/jjliggett/jjversion-gha-output/pull/26
- https://github.com/jjliggett/jjversion-gha-output/pull/29
- https://github.com/jjliggett/jjversion-gha-output/pull/30