### PR TITLE
patch: Update jjversion-gha-output to v0.3.8 from v0.3.0 for dependency updates and improved commit retrieval

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -32,13 +32,13 @@ runs:
     - run: |
         if ($env:RUNNER_OS -eq "Windows")
         {
-          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.0/jjversion-ghao.exe -L --output jjversion-gha-output.exe
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.8/jjversion-ghao.exe -L --output jjversion-gha-output.exe
         } elseif ($env:RUNNER_OS -eq "macOS")
         {
-          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.0/jjversion-ghao-darwin -L --output jjversion-gha-output
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.8/jjversion-ghao-darwin -L --output jjversion-gha-output
           chmod +x jjversion-gha-output
         } else {
-          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.0/jjversion-ghao -L --output jjversion-gha-output
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.8/jjversion-ghao -L --output jjversion-gha-output
           chmod +x jjversion-gha-output
         }
       shell: pwsh


### PR DESCRIPTION
patch: Update jjversion-gha-output to v0.3.8 (#38)

This change primarily relates to the following PR:
https://github.com/jjliggett/jjversion-gha-output/pull/44
That PR included two changes to jjversion,
consisting of updates to jjversion and also
an improvement to the commit retrieval to
better support merge commits. Those changes
were made in the following two PRs:
- https://github.com/jjliggett/jjversion/pull/174
- https://github.com/jjliggett/jjversion/pull/180
Beyond those changes, there were other older
updates to dependencies.

A full comparison of jjversion-gha-output changes can be found here: https://github.com/jjliggett/jjversion-gha-output/compare/v0.3.0...v0.3.8