### PR TITLE
patch: Update jjversion-gha-output from v0.3.8 to v0.3.11 and make a small improvement to the GitHub workflow

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,16 +29,19 @@ runs:
   steps:
     - run: echo $env:RUNNER_OS
       shell: pwsh
-    - run: |
+    - name: Download jjversion-gha-output GitHub Release executable
+      env:
+        VERSION: v0.3.11
+      run: |
         if ($env:RUNNER_OS -eq "Windows")
         {
-          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.8/jjversion-ghao.exe -L --output jjversion-gha-output.exe
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/$env:VERSION/jjversion-ghao.exe -L --output jjversion-gha-output.exe
         } elseif ($env:RUNNER_OS -eq "macOS")
         {
-          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.8/jjversion-ghao-darwin -L --output jjversion-gha-output
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/$env:VERSION/jjversion-ghao-darwin -L --output jjversion-gha-output
           chmod +x jjversion-gha-output
         } else {
-          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/v0.3.8/jjversion-ghao -L --output jjversion-gha-output
+          curl https://github.com/jjliggett/jjversion-gha-output/releases/download/$env:VERSION/jjversion-ghao -L --output jjversion-gha-output
           chmod +x jjversion-gha-output
         }
       shell: pwsh


### PR DESCRIPTION
This primarily relates to the v0.3.11 release of `jjversion-gha-output` - https://github.com/jjliggett/jjversion-gha-output/releases/tag/v0.3.11 and the most recent pull request in `jjversion-gha-output` - https://github.com/jjliggett/jjversion-gha-output/pull/49

A full list of changes between `jjversion-gha-output` versions 0.3.8 and 0.3.11 can be found here: https://github.com/jjliggett/jjversion-gha-output/compare/v0.3.8...v0.3.11

As seen in the commit change list, the changes include updating `jjversion` multiple times, in total from v0.5.20 to v0.5.24.

Those changes relate to the following changes in `jjversion`: https://github.com/jjliggett/jjversion/compare/v0.5.20...v0.5.24

As seen in those commits messages, the new changes consist of updates to dependencies including `go-billy`, `go-git`, and `golang`, e.g.:
- https://github.com/jjliggett/jjversion/pull/181
- https://github.com/jjliggett/jjversion/pull/184
- https://github.com/jjliggett/jjversion/pull/187

Beyond updating dependencies, this commit also includes a
small change to the GitHub workflow pipeline. The version
of jjversion-gha-output now is stored within a workflow
step environment variable, which reduces the quantity of
changes needed when new versions of jjversion-gha-output
are available.