### PR TITLE
patch: Update jjversion-gha-output to v0.3.13 from v0.3.11

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,7 +31,7 @@ runs:
       shell: pwsh
     - name: Download jjversion-gha-output GitHub Release executable
       env:
-        VERSION: v0.3.11
+        VERSION: v0.3.13
       run: |
         if ($env:RUNNER_OS -eq "Windows")
         {


### PR DESCRIPTION
This relates to the following changes:
- https://github.com/jjliggett/jjversion-gha-output/pull/53
- https://github.com/jjliggett/jjversion-gha-output/pull/51
- https://github.com/jjliggett/jjversion/pull/203
- https://github.com/jjliggett/jjversion/pull/202
- https://github.com/jjliggett/jjversion/pull/200