### PR TITLE
chore: Ignore .vscode/settings.json

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -5,7 +5,8 @@ on:
       - README.md
       - LICENSE.md
       - 'docs/**'
-      - '.github/dependabot.yaml' 
+      - '.github/dependabot.yaml'
+      - '.gitignore'
     branches:
       - root
   pull_request:
@@ -13,7 +14,8 @@ on:
       - README.md
       - LICENSE.md
       - 'docs/**'
-      - '.github/dependabot.yaml' 
+      - '.github/dependabot.yaml'
+      - '.gitignore'
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json


### PR DESCRIPTION
This creates a .gitignore file and adds .vscode/settings.json to it.

That file contains various VS Code configuration, such as Peacock color customizations. Those configurations should be excluded from the repository.