### PR TITLE
patch: Update jjversion-gha-output to v0.3.18 from v0.3.13

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,7 +31,7 @@ runs:
       shell: pwsh
     - name: Download jjversion-gha-output GitHub Release executable
       env:
-        VERSION: v0.3.13
+        VERSION: v0.3.18
       run: |
         if ($env:RUNNER_OS -eq "Windows")
         {


### PR DESCRIPTION
This relates to several dependency updates.

The following pull requests are related:

- https://github.com/jjliggett/jjversion-gha-output/pull/65
- https://github.com/jjliggett/jjversion-gha-output/pull/64
- https://github.com/jjliggett/jjversion-gha-output/pull/60
- https://github.com/jjliggett/jjversion-gha-output/pull/55
- https://github.com/jjliggett/jjversion-gha-output/pull/54
- https://github.com/jjliggett/jjversion/pull/247
- https://github.com/jjliggett/jjversion/pull/246
- https://github.com/jjliggett/jjversion/pull/215
- https://github.com/jjliggett/jjversion/pull/213

A full list of changes can be found in the following comparisons:

- https://github.com/jjliggett/jjversion-gha-output/compare/v0.3.13...v0.3.18
- https://github.com/jjliggett/jjversion/compare/v0.5.28...v0.5.32