### PR TITLE
patch: Update jjversion-gha-output to v0.3.22

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,7 +31,7 @@ runs:
       shell: pwsh
     - name: Download jjversion-gha-output GitHub Release executable
       env:
-        VERSION: v0.3.18
+        VERSION: v0.3.22
       run: |
         if ($env:RUNNER_OS -eq "Windows")
         {


### PR DESCRIPTION
This relates to several dependency updates.

The following pull requests are related:

- https://github.com/jjliggett/jjversion-gha-output/pull/66
- https://github.com/jjliggett/jjversion-gha-output/pull/67
- https://github.com/jjliggett/jjversion-gha-output/pull/68
- https://github.com/jjliggett/jjversion-gha-output/pull/69
- https://github.com/jjliggett/jjversion-gha-output/pull/70
- https://github.com/jjliggett/jjversion-gha-output/pull/71
- https://github.com/jjliggett/jjversion/pull/257
- https://github.com/jjliggett/jjversion/pull/258
- https://github.com/jjliggett/jjversion/pull/261
- https://github.com/jjliggett/jjversion/pull/262
- https://github.com/jjliggett/jjversion/pull/264
- https://github.com/jjliggett/jjversion/pull/266
- https://github.com/jjliggett/jjversion/pull/265
- https://github.com/jjliggett/jjversion/pull/267
- https://github.com/jjliggett/jjversion/pull/270
- https://github.com/jjliggett/jjversion/pull/269
- https://github.com/jjliggett/jjversion/pull/271

A full list of changes can be found in the following comparisons:

- https://github.com/jjliggett/jjversion-gha-output/compare/v0.3.18...v0.3.22
- https://github.com/jjliggett/jjversion/compare/v0.5.32...v0.5.43