### PR TITLE
patch: Update jjversion-gha-output to v0.3.23

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,7 +31,7 @@ runs:
       shell: pwsh
     - name: Download jjversion-gha-output GitHub Release executable
       env:
-        VERSION: v0.3.22
+        VERSION: v0.3.23
       run: |
         if ($env:RUNNER_OS -eq "Windows")
         {


### PR DESCRIPTION
This relates to:

- https://github.com/jjliggett/jjversion-gha-output/pull/73
- https://github.com/jjliggett/jjversion/pull/274