### PR TITLE
patch: Update jjversion-gha-output to v0.3.28

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,7 +31,7 @@ runs:
       shell: pwsh
     - name: Download jjversion-gha-output GitHub Release executable
       env:
-        VERSION: v0.3.23
+        VERSION: v0.3.28
       run: |
         if ($env:RUNNER_OS -eq "Windows")
         {


### PR DESCRIPTION
This relates to:

- https://github.com/jjliggett/jjversion/pull/276
- https://github.com/jjliggett/jjversion-gha-output/pull/76
- https://github.com/jjliggett/jjversion/pull/280
- https://github.com/jjliggett/jjversion-gha-output/pull/77
- https://github.com/jjliggett/jjversion-gha-output/pull/80
- https://github.com/jjliggett/jjversion-gha-output/pull/79
- https://github.com/jjliggett/jjversion/pull/283
- https://github.com/jjliggett/jjversion/pull/284
- https://github.com/jjliggett/jjversion/pull/285
- https://github.com/jjliggett/jjversion/pull/286
- https://github.com/jjliggett/jjversion-gha-output/pull/81
- https://github.com/jjliggett/jjversion/pull/288
- https://github.com/jjliggett/jjversion-gha-output/pull/83