### PR TITLE
patch: Update jjversion-gha-output to v0.3.37

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,7 @@ inputs:
   version:
     type: "string"
     required: false
-    default: "v0.3.31"
+    default: "v0.3.37"
 outputs:
   major:
     description: "Major version"


### PR DESCRIPTION
The changes to jjversion between v0.3.31 and v0.3.37 can be seen in the following two comparisons:

https://github.com/jjliggett/jjversion-gha-output/compare/v0.3.31...v0.3.37

https://github.com/jjliggett/jjversion/compare/v0.5.54...v0.5.63

This relates to:
- https://github.com/jjliggett/jjversion-gha-output/pull/88
- https://github.com/jjliggett/jjversion-gha-output/pull/87
- https://github.com/jjliggett/jjversion-gha-output/pull/89
- https://github.com/jjliggett/jjversion-gha-output/pull/91
- https://github.com/jjliggett/jjversion-gha-output/pull/92
- https://github.com/jjliggett/jjversion-gha-output/pull/93
- https://github.com/jjliggett/jjversion-gha-output/pull/94
- https://github.com/jjliggett/jjversion-gha-output/pull/95
- https://github.com/jjliggett/jjversion-gha-output/pull/96
- https://github.com/jjliggett/jjversion/pull/293
- https://github.com/jjliggett/jjversion/pull/294
- https://github.com/jjliggett/jjversion/pull/297
- https://github.com/jjliggett/jjversion/pull/296
- https://github.com/jjliggett/jjversion/pull/298
- https://github.com/jjliggett/jjversion/pull/299
- https://github.com/jjliggett/jjversion/pull/303
- https://github.com/jjliggett/jjversion/pull/302
- https://github.com/jjliggett/jjversion/pull/304
- https://github.com/jjliggett/jjversion/pull/306
- https://github.com/jjliggett/jjversion/pull/307
- https://github.com/jjliggett/jjversion/pull/308

