### PR TITLE
patch: Update jjversion-gha-output to v0.3.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ An optional parameter is available to specify the `jjversion-gha-output` executa
         id: jjversion
         uses: jjliggett/jjversion-action@d985078849e10d73a55b8c7b0aa713349a03c156 # v0.6.10
         with:
-          version: v0.3.37
+          version: v0.3.43
       - name: Display jjversion outputs
         run: |
           echo "Major: ${{ steps.jjversion.outputs.major }}"

--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,7 @@ inputs:
   version:
     type: "string"
     required: false
-    default: "v0.3.37"
+    default: "v0.3.43"
 outputs:
   major:
     description: "Major version"


### PR DESCRIPTION
This relates to:

- https://github.com/jjliggett/jjversion-gha-output/pull/108
- https://github.com/jjliggett/jjversion/pull/326

Also see:

- https://github.com/jjliggett/jjversion-gha-output/compare/v0.3.37...v0.3.43
- https://github.com/jjliggett/jjversion/compare/v0.5.63...v0.5.69
