### PR TITLE
ci: Add devcontainers to dependabot.yaml & add lock file

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2.4.1": {
+      "version": "2.4.1",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:02045d6381c5d57e3c4e0e499046724bc9c3142c97b17432456c74a82e221b97",
+      "integrity": "sha256:02045d6381c5d57e3c4e0e499046724bc9c3142c97b17432456c74a82e221b97"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,18 @@
 {
-	"name": "jjversion-action-dc",
+    "name": "jjversion-action-dc",
     "build": {
         "dockerfile": "Dockerfile"
     },
-	"features": {
-        "ghcr.io/devcontainers/features/common-utils:2.1.3": {}
-	},
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"eamodio.gitlens"
-			]
-		}
-	},
-	"remoteUser": "vscode",
-	"remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}" }
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2.4.1": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "eamodio.gitlens"
+            ]
+        }
+    },
+    "remoteUser": "vscode",
+    "remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}" }
 }

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,3 +12,16 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    assignees:
+      - "jjliggett"
+    reviewers:
+      - "jjliggett"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An example usage can be seen below:
           fetch-depth: 0
       - name: Get version
         id: jjversion
-        uses: jjliggett/jjversion-action@d985078849e10d73a55b8c7b0aa713349a03c156 # v0.6.10
+        uses: jjliggett/jjversion-action@792eedc302b25e47c032768ed951ca1c6abb5d3d # v0.6.11
       - name: Display jjversion outputs
         run: |
           echo "Major: ${{ steps.jjversion.outputs.major }}"
@@ -52,7 +52,7 @@ An optional parameter is available to specify the `jjversion-gha-output` executa
           fetch-depth: 0
       - name: Get version
         id: jjversion
-        uses: jjliggett/jjversion-action@d985078849e10d73a55b8c7b0aa713349a03c156 # v0.6.10
+        uses: jjliggett/jjversion-action@792eedc302b25e47c032768ed951ca1c6abb5d3d # v0.6.11
         with:
           version: v0.3.43
       - name: Display jjversion outputs


### PR DESCRIPTION
This is similar to:

- https://github.com/jjliggett/jjversion/pull/316
- https://github.com/jjliggett/jjversion-gha-output/pull/106

For context, see: [github.blog/changelog/2024-01-24-dependabot-version-updates-support-devcontainers](https://github.blog/changelog/2024-01-24-dependabot-version-updates-support-devcontainers/)

This is also related to the jjversion-action v0.6.11 release:

- https://github.com/jjliggett/jjversion-action/pull/72
- https://github.com/jjliggett/jjversion-action/releases/tag/v0.6.11
