### PR TITLE
patch: Update jjversion-gha-output to v0.3.46

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: ./
         id: jjversion2
         with:
-          version: v0.3.31
+          version: v0.3.46
       - name: Display jjversion outputs
         run: |
           echo "Major: ${{ steps.jjversion2.outputs.major }}"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ An optional parameter is available to specify the `jjversion-gha-output` executa
         id: jjversion
         uses: jjliggett/jjversion-action@792eedc302b25e47c032768ed951ca1c6abb5d3d # v0.6.11
         with:
-          version: v0.3.43
+          version: v0.3.46
       - name: Display jjversion outputs
         run: |
           echo "Major: ${{ steps.jjversion.outputs.major }}"

--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,7 @@ inputs:
   version:
     type: "string"
     required: false
-    default: "v0.3.43"
+    default: "v0.3.46"
 outputs:
   major:
     description: "Major version"


### PR DESCRIPTION
This relates to these changes:

https://github.com/jjliggett/jjversion-gha-output/compare/v0.3.43...v0.3.46

https://github.com/jjliggett/jjversion/compare/v0.5.69...v0.5.71

Specifically:

- https://github.com/jjliggett/jjversion-gha-output/pull/109
- https://github.com/jjliggett/jjversion-gha-output/pull/111
- https://github.com/jjliggett/jjversion-gha-output/pull/112
- https://github.com/jjliggett/jjversion-gha-output/pull/113
- https://github.com/jjliggett/jjversion-gha-output/pull/114
- https://github.com/jjliggett/jjversion-gha-output/pull/118
- https://github.com/jjliggett/jjversion-gha-output/pull/120
- https://github.com/jjliggett/jjversion-gha-output/pull/117
- https://github.com/jjliggett/jjversion-gha-output/pull/119
- https://github.com/jjliggett/jjversion-gha-output/pull/121
- https://github.com/jjliggett/jjversion-gha-output/pull/116

And:

- https://github.com/jjliggett/jjversion/pull/327
- https://github.com/jjliggett/jjversion/pull/328
- https://github.com/jjliggett/jjversion/pull/331
- https://github.com/jjliggett/jjversion/pull/332
- https://github.com/jjliggett/jjversion/pull/333
- https://github.com/jjliggett/jjversion/pull/334
- https://github.com/jjliggett/jjversion/pull/335
- https://github.com/jjliggett/jjversion/pull/337
- https://github.com/jjliggett/jjversion/pull/339
- https://github.com/jjliggett/jjversion/pull/338
- https://github.com/jjliggett/jjversion/pull/336
- https://github.com/jjliggett/jjversion/pull/340
- https://github.com/jjliggett/jjversion/pull/342
- https://github.com/jjliggett/jjversion/pull/341
- https://github.com/jjliggett/jjversion/pull/343