### PR TITLE
patch: Update jjversion-gha-output to v0.3.48

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,7 @@ inputs:
   version:
     type: "string"
     required: false
-    default: "v0.3.46"
+    default: "v0.3.48"
 outputs:
   major:
     description: "Major version"


### PR DESCRIPTION
This relates to the following changes:

- https://github.com/jjliggett/jjversion-gha-output/pull/126
- https://github.com/jjliggett/jjversion-gha-output/pull/125
- https://github.com/jjliggett/jjversion-gha-output/pull/124
- https://github.com/jjliggett/jjversion-gha-output/pull/123

https://github.com/jjliggett/jjversion-gha-output/compare/v0.3.46...v0.3.48

- https://github.com/jjliggett/jjversion/pull/357
- https://github.com/jjliggett/jjversion/pull/360
- https://github.com/jjliggett/jjversion/pull/359
- https://github.com/jjliggett/jjversion/pull/358
- https://github.com/jjliggett/jjversion/pull/356
- https://github.com/jjliggett/jjversion/pull/355
- https://github.com/jjliggett/jjversion/pull/354
- https://github.com/jjliggett/jjversion/pull/351
- https://github.com/jjliggett/jjversion/pull/353
- https://github.com/jjliggett/jjversion/pull/350
- https://github.com/jjliggett/jjversion/pull/348
- https://github.com/jjliggett/jjversion/pull/349
- https://github.com/jjliggett/jjversion/pull/347
- https://github.com/jjliggett/jjversion/pull/346
- https://github.com/jjliggett/jjversion/pull/345
- https://github.com/jjliggett/jjversion/pull/344

https://github.com/jjliggett/jjversion/compare/v0.5.71...v0.5.74